### PR TITLE
Created a Repeat component to render repeated components

### DIFF
--- a/src/components/AnimatedPath.js
+++ b/src/components/AnimatedPath.js
@@ -1,8 +1,8 @@
 import React, { useRef, useEffect } from "react";
 import { connect } from "react-redux";
-import { getPathInfo } from "../redux/selectors";
+import { getNode, getEdge } from "../redux/selectors";
 
-const AnimatedPath = ({ no, end, pathInfo: { source, target, edge } }) => {
+const AnimatedPath = ({ no, end, source, target, edge }) => {
   const drawing = useRef(null);
 
   useEffect(() => {
@@ -33,7 +33,9 @@ const AnimatedPath = ({ no, end, pathInfo: { source, target, edge } }) => {
 };
 
 const mapStateToProps = (state, { sourceId, targetId }) => ({
-  pathInfo: getPathInfo(sourceId, targetId)(state)
+  source: getNode(sourceId)(state),
+  target: getNode(targetId)(state),
+  edge: getEdge(sourceId, targetId)(state)
 });
 
 export default connect(mapStateToProps)(AnimatedPath);

--- a/src/components/Path.js
+++ b/src/components/Path.js
@@ -1,24 +1,33 @@
 import React from "react";
 import { connect } from "react-redux";
-import { getPathInfo } from "../redux/selectors";
+import { getNode, getEdge } from "../redux/selectors";
 
-const Path = ({ id, pathInfo: { source, target, edge } }) => (
-  <g>
-    <path
-      id={id}
-      d={`M ${source.x},${source.y} L ${target.x},${target.y}`}
-      className="stroke-current stroke-2 text-purple-500"
-    />
-    <text>
-      <textPath href={"#" + id} startOffset="50%" textAnchor="middle">
-        {edge.toFixed(2)}
-      </textPath>
-    </text>
-  </g>
-);
+const Path = ({ id, source, target, edge }) => {
+  if (!edge || source.x > target.x) {
+    return null;
+  }
+
+  return (
+    <g>
+      <path
+        id={id}
+        d={`M ${source.x},${source.y} L ${target.x},${target.y}`}
+        className="stroke-current stroke-2 text-purple-500"
+      />
+      <text>
+        <textPath href={"#" + id} startOffset="50%" textAnchor="middle">
+          {edge.toFixed(2)}
+        </textPath>
+      </text>
+    </g>
+  );
+};
 
 const mapStateToProps = (state, { sourceId, targetId }) => ({
-  pathInfo: getPathInfo(sourceId, targetId)(state)
+  id: "path" + sourceId + targetId,
+  source: getNode(sourceId)(state),
+  target: getNode(targetId)(state),
+  edge: getEdge(sourceId, targetId)(state)
 });
 
 export default connect(mapStateToProps)(Path);

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -1,8 +1,8 @@
 import React from "react";
 import { connect } from "react-redux";
 import { updateGraph, resetResult } from "../redux/actions";
-import { getNodesCount } from "../redux/selectors";
 
+import Repeat from "./Repeat";
 import Node from "./Node";
 import Path from "./Path";
 import ShowResult from "./ShowResult";
@@ -33,9 +33,8 @@ class Playground extends React.Component {
   };
 
   render() {
-    const { edges, nodeCount, shown } = this.props;
+    const { shown } = this.props;
     const { width, height } = this.state;
-    const keys = [...Array(nodeCount).keys()];
 
     return (
       <svg
@@ -43,33 +42,17 @@ class Playground extends React.Component {
         className="absolute bottom-0"
         viewBox={`${-width / 8} ${-height / 8} ${width} ${height}`}
       >
-        {edges.map((source, i) =>
-          source.map((target, j) => {
-            if (!target || i > j) {
-              return null;
-            }
-
-            return <Path key={`${i}${j}`} id={`path${i}${j}`} sourceId={i} targetId={j} />;
-          })
-        )}
+        <Repeat>{idx => <Node key={idx} idx={idx} width={width} height={height} />}</Repeat>
+        <Repeat>
+          {i => <Repeat key={i}>{j => <Path key={`${i}${j}`} sourceId={i} targetId={j} />}</Repeat>}
+        </Repeat>
         {shown && <ShowResult />}
-        {keys.map(key => (
-          <Node key={key} idx={key} width={width} height={height} />
-        ))}
       </svg>
     );
   }
 }
 
-const mapStateToProps = state => {
-  const { graph, result } = state;
-
-  return {
-    edges: graph.edges,
-    nodeCount: getNodesCount(state),
-    shown: result.shown
-  };
-};
+const mapStateToProps = ({ result: { shown } }) => ({ shown });
 
 const mapDispatchToProps = dispatch => ({
   updateGraph: (forX, forY) => dispatch(updateGraph(forX, forY)),

--- a/src/components/Repeat.js
+++ b/src/components/Repeat.js
@@ -1,0 +1,16 @@
+import { connect } from "react-redux";
+import { getNodesCount } from "../redux/selectors";
+
+const Repeat = ({ nodesCount, children }) => {
+  const items = [];
+
+  for (let i = 0; i < nodesCount; i++) {
+    items.push(children(i));
+  }
+
+  return items;
+};
+
+const mapStateToProps = state => ({ nodesCount: getNodesCount(state) });
+
+export default connect(mapStateToProps)(Repeat);

--- a/src/components/SetLinks.js
+++ b/src/components/SetLinks.js
@@ -3,6 +3,7 @@ import { connect } from "react-redux";
 
 import CustomSelect from "./CustomSelect";
 import ChangeLabel from "./ChangeLabel";
+import Repeat from "./Repeat";
 import LinkedTo from "./LinkedTo";
 import { ReactComponent as CloseOutline } from "../assets/close-outline.svg";
 
@@ -27,9 +28,9 @@ const Popover = ({ edges }) => {
           <ChangeLabel key={selectedId} id={selectedId} />
           <div>
             <p className="label mb-2 border-b-4 border-teal-500 py-1">Linked To</p>
-            {edges[selectedId].map((edge, idx) => (
-              <LinkedTo key={`${selectedId}${idx}`} source={selectedId} target={idx} />
-            ))}
+            <Repeat>
+              {idx => <LinkedTo key={`${selectedId}${idx}`} source={selectedId} target={idx} />}
+            </Repeat>
           </div>
         </div>
       </div>

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -11,13 +11,6 @@ export const getNode = id => createSelector([getNodes], nodes => nodes[id]);
 export const getEdge = (sourceId, targetId) =>
   createSelector([getEdges], edges => edges[sourceId][targetId]);
 
-export const getPathInfo = (sourceId, targetId) =>
-  createSelector([getNodes, getEdges], (nodes, edges) => ({
-    source: nodes[sourceId],
-    target: nodes[targetId],
-    edge: edges[sourceId][targetId]
-  }));
-
 export const getNodeLabels = createSelector([getNodes], nodes => nodes.map(node => node.label));
 
 export const getNodeLabel = id => createSelector([getNodeLabels], nodeLabels => nodeLabels[id]);


### PR DESCRIPTION
- Node, Path and Linked To components are rendered by the **Repeat component** so that other components don't need to get props(nodes and edges) just to pass them to their child components.
- Deleted a Redux selector Get Path Info as it can be replaced by Get Node and Get Edge selectors.