### PR TITLE
Changed functions to make them work well in both cases

### DIFF
--- a/src/components/AnimatedPath.js
+++ b/src/components/AnimatedPath.js
@@ -2,7 +2,7 @@ import React, { useRef, useEffect } from "react";
 import { connect } from "react-redux";
 import { getNode, getEdge } from "../redux/selectors";
 
-const AnimatedPath = ({ no, end, source, target, edge }) => {
+const AnimatedPath = ({ no, end, source, target, dashoffset }) => {
   const drawing = useRef(null);
 
   useEffect(() => {
@@ -15,27 +15,35 @@ const AnimatedPath = ({ no, end, source, target, edge }) => {
     <path
       d={`M ${source.x},${source.y} L ${target.x},${target.y}`}
       className="stroke-current stroke-5 text-red-600"
-      strokeDasharray={edge}
-      strokeDashoffset={edge}
+      strokeDasharray={dashoffset}
+      strokeDashoffset={dashoffset}
     >
       <animate
         id={"route" + no}
         attributeName="stroke-dashoffset"
-        values={edge + "; 0"}
+        values={dashoffset + "; 0"}
         begin={!no ? `indefinite; ${end} + 2s` : `route${no - 1}.end`}
-        dur={edge / 500 + "s"}
+        dur={dashoffset / 500 + "s"}
         fill="freeze"
         ref={drawing}
       />
-      <set attributeName="stroke-dashoffset" to={edge} begin={end + " + 1s"} fill="freeze" />
+      <set attributeName="stroke-dashoffset" to={dashoffset} begin={end + " + 1s"} fill="freeze" />
     </path>
   );
 };
 
-const mapStateToProps = (state, { sourceId, targetId }) => ({
-  source: getNode(sourceId)(state),
-  target: getNode(targetId)(state),
-  edge: getEdge(sourceId, targetId)(state)
-});
+const mapStateToProps = (state, { sourceId, targetId }) => {
+  let source = getNode(sourceId)(state);
+  let target = getNode(targetId)(state);
+  let dashoffset;
+
+  if (state.graph.useRealDist) {
+    dashoffset = getEdge(sourceId, targetId)(state);
+  } else {
+    dashoffset = Math.hypot(source.x - target.x, source.y - target.y);
+  }
+
+  return { source, target, dashoffset };
+};
 
 export default connect(mapStateToProps)(AnimatedPath);

--- a/src/components/Header.js
+++ b/src/components/Header.js
@@ -1,16 +1,19 @@
 import React, { useState } from "react";
 import { connect } from "react-redux";
-import { changeSetting } from "../redux/actions";
+import { changeSetting, resetResult } from "../redux/actions";
 import { getIsResultSet } from "../redux/selectors";
 
 import CustomButton from "./CustomButton";
 import SetLinks from "./SetLinks";
 import ResultContainer from "./ResultContainer";
 
-const Header = ({ useRealDist, isResultSet, changeSetting }) => {
+const Header = ({ useRealDist, isResultSet, changeSetting, resetResult }) => {
   const [showSetting, setShowSetting] = useState(false);
 
-  const handleChange = () => changeSetting();
+  const handleChange = () => {
+    changeSetting();
+    resetResult();
+  };
   const handleClick = () => setShowSetting(!showSetting);
   const handleClose = () => setShowSetting(false);
 
@@ -46,7 +49,8 @@ const mapStateToProps = state => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  changeSetting: () => dispatch(changeSetting())
+  changeSetting: () => dispatch(changeSetting()),
+  resetResult: () => dispatch(resetResult())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Header);

--- a/src/components/LinkedTo.js
+++ b/src/components/LinkedTo.js
@@ -1,15 +1,20 @@
 import React from "react";
 import { connect } from "react-redux";
-import { updateEdge } from "../redux/actions";
+import { updateEdge, resetResult } from "../redux/actions";
 import { getNodeLabel, getEdge } from "../redux/selectors";
 
-const LinkedTo = ({ source, target, useRealDist, label, edge, updateEdge }) => {
+const LinkedTo = ({ source, target, useRealDist, label, edge, updateEdge, resetResult }) => {
   const handleChange = ({ target: { type, checked, value } }) => {
+    let cost;
+
     if (type === "checkbox") {
-      return updateEdge(source, target, +checked);
+      cost = +checked;
+    } else {
+      cost = +value <= 20 ? +value : 20;
     }
 
-    return updateEdge(source, target, +value);
+    updateEdge(source, target, cost);
+    resetResult();
   };
 
   return (
@@ -46,7 +51,8 @@ const mapStateToProps = (state, { source, target }) => ({
 });
 
 const mapDispatchToProps = dispatch => ({
-  updateEdge: (source, target, edge) => dispatch(updateEdge(source, target, edge))
+  updateEdge: (source, target, edge) => dispatch(updateEdge(source, target, edge)),
+  resetResult: () => dispatch(resetResult())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(LinkedTo);

--- a/src/components/Node.js
+++ b/src/components/Node.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { updateNode, updateEdges, resetResult } from "../redux/actions";
+import { updateNode, updateEdges, resetResult, stopAnimation } from "../redux/actions";
 import { getNode } from "../redux/selectors";
 import { checkBoundary } from "../helpers";
 
@@ -20,8 +20,13 @@ class Node extends React.Component {
   }
 
   handleMouseDown = () => {
-    const { resetResult } = this.props;
-    resetResult();
+    const { useRealDist, resetResult, stopAnimation } = this.props;
+
+    if (useRealDist) {
+      resetResult();
+    } else {
+      stopAnimation();
+    }
 
     window.addEventListener("mousemove", this.handleMouseMove);
     window.addEventListener("mouseup", this.handleMouseUp);
@@ -54,8 +59,11 @@ class Node extends React.Component {
     window.removeEventListener("mousemove", this.handleMouseMove);
     window.removeEventListener("mouseup", this.handleMouseUp);
 
-    const { updateEdges, idx } = this.props;
-    updateEdges(idx);
+    const { useRealDist, updateEdges, idx } = this.props;
+
+    if (useRealDist) {
+      updateEdges(idx);
+    }
 
     this.setState({ onDrag: false, screenCTM: null });
   };
@@ -63,24 +71,32 @@ class Node extends React.Component {
   render() {
     const {
       idx,
-      node: { label, x, y }
+      node: { label, x, y },
+      useRealDist
     } = this.props;
 
     return (
       <g id={"node" + idx} transform={`translate(${x}, ${y})`} onMouseDown={this.handleMouseDown}>
         <circle r="5" />
-        <text dy={y > 100 ? 15 : -5}>{`${label} (${x.toFixed(2)}, ${y.toFixed(2)})`}</text>
+        <text dy={y > 100 ? 15 : -5}>
+          {label}
+          {useRealDist ? `(${x.toFixed(2)}, ${y.toFixed(2)})` : null}
+        </text>
       </g>
     );
   }
 }
 
-const mapStateToProps = (state, { idx }) => ({ node: getNode(idx)(state) });
+const mapStateToProps = (state, { idx }) => ({
+  useRealDist: state.graph.useRealDist,
+  node: getNode(idx)(state)
+});
 
 const mapDispatchToProps = dispatch => ({
   updateNode: (idx, updateInfo) => dispatch(updateNode(idx, updateInfo)),
   updateEdges: idx => dispatch(updateEdges(idx)),
-  resetResult: () => dispatch(resetResult())
+  resetResult: () => dispatch(resetResult()),
+  stopAnimation: () => dispatch(stopAnimation())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Node);

--- a/src/components/Path.js
+++ b/src/components/Path.js
@@ -2,7 +2,7 @@ import React from "react";
 import { connect } from "react-redux";
 import { getNode, getEdge } from "../redux/selectors";
 
-const Path = ({ id, source, target, edge }) => {
+const Path = ({ id, source, target, edge, useRealDist }) => {
   if (!edge || source.x > target.x) {
     return null;
   }
@@ -16,7 +16,7 @@ const Path = ({ id, source, target, edge }) => {
       />
       <text>
         <textPath href={"#" + id} startOffset="50%" textAnchor="middle">
-          {edge.toFixed(2)}
+          {useRealDist ? edge.toFixed(2) : edge}
         </textPath>
       </text>
     </g>
@@ -27,7 +27,8 @@ const mapStateToProps = (state, { sourceId, targetId }) => ({
   id: "path" + sourceId + targetId,
   source: getNode(sourceId)(state),
   target: getNode(targetId)(state),
-  edge: getEdge(sourceId, targetId)(state)
+  edge: getEdge(sourceId, targetId)(state),
+  useRealDist: state.graph.useRealDist
 });
 
 export default connect(mapStateToProps)(Path);

--- a/src/components/Playground.js
+++ b/src/components/Playground.js
@@ -1,6 +1,6 @@
 import React from "react";
 import { connect } from "react-redux";
-import { updateGraph, resetResult } from "../redux/actions";
+import { updateGraph, resetResult, stopAnimation } from "../redux/actions";
 
 import Repeat from "./Repeat";
 import Node from "./Node";
@@ -23,8 +23,13 @@ class Playground extends React.Component {
   }
 
   handleResize = ({ target: { innerWidth, innerHeight } }) => {
-    const { resetResult, updateGraph } = this.props;
-    resetResult();
+    const { useRealDist, resetResult, stopAnimation } = this.props;
+
+    if (useRealDist) {
+      resetResult();
+    } else {
+      stopAnimation();
+    }
 
     const { width, height } = this.state;
     updateGraph((innerWidth * 0.8) / width, (innerHeight * 0.85) / height);
@@ -45,18 +50,19 @@ class Playground extends React.Component {
         <Repeat>
           {i => <Repeat key={i}>{j => <Path key={`${i}${j}`} sourceId={i} targetId={j} />}</Repeat>}
         </Repeat>
-        <Repeat>{idx => <Node key={idx} idx={idx} width={width} height={height} />}</Repeat>
         {shown && <ShowResult />}
+        <Repeat>{idx => <Node key={idx} idx={idx} width={width} height={height} />}</Repeat>
       </svg>
     );
   }
 }
 
-const mapStateToProps = ({ result: { shown } }) => ({ shown });
+const mapStateToProps = ({ graph: { useRealDist }, result: { shown } }) => ({ useRealDist, shown });
 
 const mapDispatchToProps = dispatch => ({
   updateGraph: (forX, forY) => dispatch(updateGraph(forX, forY)),
-  resetResult: () => dispatch(resetResult())
+  resetResult: () => dispatch(resetResult()),
+  stopAnimation: () => dispatch(stopAnimation())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(Playground);

--- a/src/components/ResultContainer.js
+++ b/src/components/ResultContainer.js
@@ -1,12 +1,12 @@
 import React from "react";
 import { connect } from "react-redux";
-import { toggleResultShown } from "../redux/actions";
+import { toggleAnimationShown } from "../redux/actions";
 import { getPathInLabel } from "../redux/selectors";
 
 import CustomButton from "./CustomButton";
 import { ReactComponent as ExclamationOutline } from "../assets/exclamation-outline.svg";
 
-const ResultContainer = ({ source, target, path, shown, toggleResultShown }) => {
+const ResultContainer = ({ useRealDist, source, target, path, shown, toggleAnimationShown }) => {
   if (!path) {
     return (
       <h2 className="mt-2 pt-2 border-t border-gray-300">
@@ -21,28 +21,31 @@ const ResultContainer = ({ source, target, path, shown, toggleResultShown }) => 
       <div>
         <h2>{`The shortest path is ${path}.`}</h2>
         <p className="text-sm italic">
-          *The result would be reset if you resize the browser window or change the position of a
-          node.
+          *The result will reset if you change node settings
+          {useRealDist ? ", resize the browser window or move the position of the nodes." : "."}
         </p>
       </div>
       <CustomButton
         content={`${shown ? "Stop" : "Restart"} Animation`}
         outline={true}
         color="green"
-        handleClick={toggleResultShown}
+        handleClick={toggleAnimationShown}
       />
     </div>
   );
 };
 
 const mapStateToProps = state => {
-  const { source, target, shown } = state.result;
+  const {
+    graph: { useRealDist },
+    result: { source, target, shown }
+  } = state;
 
-  return { source, target, path: getPathInLabel(state), shown };
+  return { useRealDist, source, target, path: getPathInLabel(state), shown };
 };
 
 const mapDispatchToProps = dispatch => ({
-  toggleResultShown: () => dispatch(toggleResultShown())
+  toggleAnimationShown: () => dispatch(toggleAnimationShown())
 });
 
 export default connect(mapStateToProps, mapDispatchToProps)(ResultContainer);

--- a/src/helpers.js
+++ b/src/helpers.js
@@ -1,21 +1,21 @@
-const alphabet = "ABCDEFGHIJKLMNOPQRSTUVWXYZ";
+const labels = [
+  "Bakery",
+  "City Hall",
+  "Dry Cleaner",
+  "Home",
+  "Library",
+  "Museum",
+  "Pub",
+  "Supermarket",
+  "University"
+];
 
 export const generateNodes = (num, maxX, maxY) => {
   const nodes = [];
-  const len = alphabet.length;
 
-  for (let i = 0, label, firstChar; i < num; i++) {
-    if (i < len) {
-      label = alphabet[i];
-    } else if (i % len === 0) {
-      firstChar = alphabet[i / len - 1];
-      label = firstChar + alphabet[0];
-    } else {
-      label = firstChar + alphabet[i % len];
-    }
-
+  for (let i = 0; i < num; i++) {
     nodes.push({
-      label,
+      label: labels[i],
       x: Math.random() * (maxX * 0.75),
       y: Math.random() * (maxY * 0.75)
     });
@@ -24,20 +24,21 @@ export const generateNodes = (num, maxX, maxY) => {
   return nodes;
 };
 
-const generateLinks = nodes => {
-  const randomNum = () => Math.floor(Math.random() * nodes.length);
+const randomNum = maxValue => Math.floor(Math.random() * maxValue);
+
+const generateLinks = nodesCount => {
   const links = {};
 
-  for (let source = 0; source < nodes.length; source++) {
+  for (let source = 0; source < nodesCount; source++) {
     if (!links[source]) {
       links[source] = {};
     }
 
     if (Object.keys(links[source]).length < 2) {
-      const targets = [randomNum(), randomNum()];
+      const targets = [randomNum(nodesCount), randomNum(nodesCount)];
 
       while (targets[0] === source && targets[1] === source) {
-        targets[0] = randomNum();
+        targets[0] = randomNum(nodesCount);
       }
 
       targets.forEach(target => {
@@ -56,31 +57,42 @@ const generateLinks = nodes => {
   return links;
 };
 
-export const generateEdges = nodes => {
-  const edges = [];
-  const links = generateLinks(nodes);
+export const generateEdges = (nodes, useRealDist, edges) => {
+  const newEdges = [];
+
+  if (!edges) {
+    edges = generateLinks(nodes.length);
+  }
+
+  const setCost = (i, j) => {
+    if (!edges[i][j]) {
+      return 0;
+    }
+
+    if (i > j) {
+      return newEdges[j][i];
+    }
+
+    if (!useRealDist) {
+      return 1 + randomNum(20);
+    }
+
+    const source = nodes[i];
+    const target = nodes[j];
+    return Math.hypot(target.x - source.x, target.y - source.y);
+  };
 
   for (let i = 0; i < nodes.length; i++) {
     const arr = [];
 
-    for (let j = 0, r; j < nodes.length; j++) {
-      if (!links[i][j]) {
-        r = 0;
-      } else if (i > j) {
-        r = edges[j][i];
-      } else {
-        const source = nodes[i];
-        const target = nodes[j];
-        r = Math.hypot(target.x - source.x, target.y - source.y);
-      }
-
-      arr.push(r);
+    for (let j = 0; j < nodes.length; j++) {
+      arr.push(setCost(i, j));
     }
 
-    edges.push(arr);
+    newEdges.push(arr);
   }
 
-  return edges;
+  return newEdges;
 };
 
 export const findTheShortestPath = (edges, source, target) => {

--- a/src/redux/actions.js
+++ b/src/redux/actions.js
@@ -1,14 +1,23 @@
 import { generateNodes, generateEdges, findTheShortestPath } from "../helpers";
 
-export const changeSetting = () => ({ type: "CHANGE_SETTING" });
+export const changeSetting = () => {
+  return (dispatch, getState) => {
+    const { useRealDist, nodes, edges } = getState().graph;
+
+    return dispatch({ type: "CHANGE_SETTING", edges: generateEdges(nodes, !useRealDist, edges) });
+  };
+};
 
 export const generateGraph = (num, maxX, maxY) => {
-  const nodes = generateNodes(num, maxX, maxY);
+  return (dispatch, getState) => {
+    const nodes = generateNodes(num, maxX, maxY);
+    const { useRealDist } = getState().graph;
 
-  return {
-    type: "GENERATE_GRAPH",
-    nodes,
-    edges: generateEdges(nodes)
+    return dispatch({
+      type: "GENERATE_GRAPH",
+      nodes,
+      edges: generateEdges(nodes, useRealDist)
+    });
   };
 };
 
@@ -64,14 +73,16 @@ export const updateEdges = idx => {
 
 export const updateGraph = (forX, forY) => {
   return (dispatch, getState) => {
-    let { nodes, edges } = getState().graph;
+    let { useRealDist, nodes, edges } = getState().graph;
 
     nodes.forEach((node, idx) => {
       nodes[idx] = { ...nodes[idx], x: node.x * forX, y: node.y * forY };
     });
 
-    for (let i = 0; i < edges.length - 1; i++) {
-      edges = calcEdges(nodes, edges, i, true);
+    if (useRealDist) {
+      for (let i = 0; i < edges.length - 1; i++) {
+        edges = calcEdges(nodes, edges, i, true);
+      }
     }
 
     return dispatch({ type: "UPDATE_GRAPH", nodes, edges });
@@ -111,4 +122,14 @@ export const resetResult = () => {
   };
 };
 
-export const toggleResultShown = () => ({ type: "TOGGLE_RESULT_SHOWN" });
+export const stopAnimation = () => {
+  return (dispatch, getState) => {
+    const { shown } = getState().result;
+
+    if (shown) {
+      return dispatch({ type: "STOP_ANIMATION" });
+    }
+  };
+};
+
+export const toggleAnimationShown = () => ({ type: "TOGGLE_ANIMATION_SHOWN" });

--- a/src/redux/reducers.js
+++ b/src/redux/reducers.js
@@ -5,6 +5,7 @@ const graph = (state = { nodes: null, edges: null, useRealDist: false }, action)
     case "CHANGE_SETTING":
       return {
         ...state,
+        edges: action.edges,
         useRealDist: !state.useRealDist
       };
     case "GENERATE_GRAPH":
@@ -44,7 +45,12 @@ const result = (state = INITIAL_STATE, action) => {
       };
     case "RESET_RESULT":
       return INITIAL_STATE;
-    case "TOGGLE_RESULT_SHOWN":
+    case "STOP_ANIMATION":
+      return {
+        ...state,
+        shown: false
+      };
+    case "TOGGLE_ANIMATION_SHOWN":
       return {
         ...state,
         shown: !state.shown

--- a/src/redux/selectors.js
+++ b/src/redux/selectors.js
@@ -35,5 +35,5 @@ export const getPathInLabel = createSelector([getNodeLabels, getPath], (nodeLabe
     pathInLabel.push(nodeLabels[path[i]]);
   }
 
-  return pathInLabel.join("-");
+  return pathInLabel.join(" - ");
 });


### PR DESCRIPTION
**A user can choose one of these settings: Use real distance as a cost / Set your own costs**
- Edges are generated in different ways depending on an setting that a user choose. 
- Added a function that calculate dashoffset to Animated Path component as edge isn't actual length in 'set your own costs' mode.
- Result will reset if a user change the setting, costs of edges or relationship between nodes.  
- Changing the settings above will change costs of edges.
- When a user resize the browser window or move the position of the nodes in 'set your own costs' mode, Result Container component won't be removed because it won't update any costs of edges, but Animated Path components will unmount.

**etc**
- Changed node labels from alphabet.